### PR TITLE
Docker-compose enhancements for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+class-wp-bootstrap-navwalker.php

--- a/docker/docker-compose-install.sh
+++ b/docker/docker-compose-install.sh
@@ -1,28 +1,112 @@
 #!/bin/sh
 
 # Clean up any old containers
-docker-compose down -v
+function cleanup {
+    docker-compose down -v
+}
 
 # Bring up MySQL backend
-docker-compose up -d mysql && sleep 5
+function launch-mysql {
+    docker-compose up -d mysql && sleep 15
+}
 
 # Download WordPress
-docker-compose run --rm wp core download
+function download-wordpress {
+    docker-compose run --rm wp core download
+}
 
 # Start WordPress
-docker-compose up -d wordpress && sleep 5
+function launch-wordpress {
+    docker-compose up -d wordpress && sleep 5
+}
 
 # Install BostonDSA Site
-docker-compose run --rm wp sh -c '\
-  wp core install \
-    --url="${WP_URL}"  \
-    --title="${WP_TITLE}" \
-    --admin_user="${WP_ADMIN_USER}" \
-    --admin_password="${WP_ADMIN_PASSOWRD}" \
-    --admin_email="${WP_ADMIN_EMAIL}"'
+function initialize-wordpress {
+    docker-compose run --rm wp sh -c '\
+      wp core install \
+        --url="${WP_URL}"  \
+        --title="${WP_TITLE}" \
+        --admin_user="${WP_ADMIN_USER}" \
+        --admin_password="${WP_ADMIN_PASSOWRD}" \
+        --admin_email="${WP_ADMIN_EMAIL}"'
+}
 
-# Install & Activate BostonDSA Theme
-docker-compose run --rm wp sh -c '\
-  wp theme install understrap; \
-  wp theme install "${BOSTON_DSA_THEME}"; \
-  wp theme activate Boston-DSA-Theme'
+# Connect to MySQL (as root)
+function connect-db {
+    docker-compose run --rm mysql sh -c '\
+      exec mysql --host=docker_mysql_1 --user=root --password="${MYSQL_ROOT_PASSWORD}" ${MYSQL_DATABASE}'
+}
+
+# Drop existing DB and then load a MySQL dump from file
+function drop-and-load-db {
+    echo "Dropping database..."
+    docker-compose run --rm mysql sh -c '\
+      exec mysql --host=docker_mysql_1 --user=root --password="${MYSQL_ROOT_PASSWORD}" \
+        -e "DROP DATABASE IF EXISTS ${MYSQL_DATABASE}; CREATE DATABASE IF NOT EXISTS ${MYSQL_DATABASE};"'
+    echo "Loading MySQL dump file ($1)..."
+    docker exec -i docker_mysql_1 mysql -uroot -psomewordpress wordpress < $1
+}
+
+function update-url {
+    docker-compose run --rm wp sh -c '\
+      wp option update siteurl "http://${WP_URL}"; \
+      wp option update home "http://${WP_URL}"'
+}
+
+# The default user gets blown away during a database load,
+# add it back in.
+function create-admin-user {
+    docker-compose run --rm wp sh -c '\
+      wp user create ${WP_ADMIN_USER} ${WP_ADMIN_EMAIL} --user_pass=${WP_ADMIN_PASSWORD} --role=administrator'
+}
+
+# Install plugins
+function install-plugins {
+    docker-compose run --rm wp sh -c '\
+      wp plugin install ${WP_PLUGINS} --activate'
+}
+
+# Install BostonDSA Theme
+function install-theme {
+    docker-compose run --rm wp sh -c 'wp theme install understrap'
+}
+
+# This file is "required" in the theme
+function get-bootstrap-navwalker {
+    echo "Downloading bootstrap navwalker"
+    curl -o ../class-wp-bootstrap-navwalker.php https://raw.githubusercontent.com/wp-bootstrap/wp-bootstrap-navwalker/master/class-wp-bootstrap-navwalker.php
+}
+
+# Activate BostonDSA Theme
+# The theme is loaded as a bind mount so share the volume from the wordpress
+# install with the CLI.
+function activate-theme {
+    docker run -it --rm \
+	   --volumes-from docker_wordpress_1 \
+	   --network container:docker_wordpress_1 \
+	   wordpress:cli theme activate boston-dsa-theme
+}
+
+# If this file is being executed run through the install. If this file gets
+# sourced it will just load the functions.
+# $1 can be an optional MySQL dump file to load
+if [[ "$(basename -- "$0")" == "docker-compose-install.sh" ]]; then
+    cleanup
+    launch-mysql
+    download-wordpress
+    launch-wordpress
+    initialize-wordpress
+
+    if [ ! -z $1 ]
+    then
+	drop-and-load-db $1
+	update-url
+	create-admin-user
+    fi
+
+    install-plugins
+    install-theme
+    get-bootstrap-navwalker
+    activate-theme
+
+fi

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,20 +17,26 @@ services:
       WORDPRESS_DB_HOST: mysql:3306
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_TABLE_PREFIX: 0c1_
+      WORDPRESS_DEBUG: 0
     image: wordpress
     ports:
       - 8000:80
     restart: always
     volumes:
       - wordpress:/var/www/html
+      # Bind mount this repo into the container
+      # Note: this is invisible to the wp-cli container
+      - ..:/var/www/html/wp-content/themes/boston-dsa-theme
   wp:
     environment:
-      BOSTON_DSA_THEME: https://github.com/BostonDSA/Boston-DSA-Theme/archive/master.zip
       WP_URL: localhost:8000
       WP_TITLE: BostonDSA
       WP_ADMIN_USER: admin
-      WP_ADMIN_PASSOWRD: admin
+      WP_ADMIN_PASSWORD: admin
       WP_ADMIN_EMAIL: admin@bostondsa.org
+      # ommited plugins: wps-hide-login
+      WP_PLUGINS: application-passwords advanced-custom-fields contact-form-7 custom-post-type-ui document-gallery event-tickets jwt-authentication-for-wp-rest-api private-content-login-redirect redirection the-events-calendar user-shortcodes-plus wp-fastest-cache wp-rss-aggregator
     image: wordpress:cli
     volumes:
       - wordpress:/var/www/html


### PR DESCRIPTION
- Split installation tasks into functions.

- Add a "main" check so that installation functions can be loaded, but not
  immediately run.

- Add ability to specify a production MySQL database dump file as well
  as tweaks for converting any production settings that aren't sandbox
  friendly.

- Install the dependent plugins (except for feed-them-social which no
  longer exists and rssimport which is still in development).

- Install parent theme (understrap).

- Fetch 3rd party class-wp-bootstrap-navwalker.php which the theme requires.

- Change the theme loading mechanism from installing via zip file to
  loading the local repository via bind mount.